### PR TITLE
Process the contributors as a block

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -182,7 +182,7 @@ namespace ThankYou
                     {
                         //if contributor already exists
 
-                        var thankYouLine = line.Replace("[//]: # (ThankYouTemplate:", "").Replace("@name", contributor); //This is broken
+                        var thankYouLine = line.Replace("[//]: # (ThankYouTemplate:", "").Replace("@name", contributor);
                         newContributorLines.Add(thankYouLine.Substring(0, thankYouLine.Length - 1));
                     }
                 }


### PR DESCRIPTION
Again this is completely untested but the basic idea is that it would process files that look like this:

```
blah
blah

[//]: # (ThankYouBlockStart)
[//]: # (ThankYouTemplate: * @name)
* Emad
* Mitch
[//]: # (ThankYouBlockEnd)

blah
```

The idea is:
* Process every line, and add each to a list
* When it sees the start block line, it switches modes to be in "collect contributors" mode
* When it sees the template, it builds a list of new lines that might need to be added
* When in collection mode, any other line that is seen is added to a separate "existing" list
* When it sees the end block line, it outputs the lines for the new contributors that weren't in the existing list, then reverts to normal processing

Sorry, this is once again complete untested. I couldn't be bothered generating an auth token and working out how to actually set it up :P
Maybe I'll write some tests next time :)